### PR TITLE
docs: add mac os installation steps 

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,23 @@
 <img src="assets/mocha.webp"/>
 </details>
 
-## Usage
+## How to Install 
 
-1. Clone this repository locally, and `cd` into it.
-2. Copy the flavour you want from `./dist` to `~/.config/k9s/skin.yml`:
+Clone this repository locally and copy the flavour you want:
 
+<b>Linux:</b>
 ```bash
-cp ./dist/frappe.yml ~/.config/k9s/skin.yml
+K9S_CONFIG_PATH="${XDG_CONFIG_HOME:-$HOME/.config}/k9s"
+git clone https://github.com/catppuccin/k9s.git "${K9S_CONFIG_PATH}/skins/catppuccin" --depth 1
+cp "${K9S_CONFIG_PATH}/skins/catppuccin/dist/frappe.yml" "${K9S_CONFIG_PATH}/skin.yml"
+```
+
+
+<b>Mac OS:</b>
+```bash
+K9S_CONFIG_PATH="${XDG_CONFIG_HOME:-$HOME/Library/Application Support}/k9s"
+git clone https://github.com/catppuccin/k9s.git "${K9S_CONFIG_PATH}/skins/catppuccin" --depth 1
+cp "${K9S_CONFIG_PATH}/skins/catppuccin/dist/mocha.yml" "${K9S_CONFIG_PATH}/skin.yml"
 ```
 
 ## 💝 Thanks to


### PR DESCRIPTION
As per k9s docs the path used in Mac OS differs compared to Linux. 
https://github.com/derailed/k9s#k9s-configuration

This patch provides copy and paste steps to clone the repo in the K9s config path, and then copying the skin in the right location. 

I considered also deleting the cloned repo at the end, but I think it's worth keeping it in case one wants to change skin in the future.