### PR TITLE
docs: fix tar command in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@
 ```bash
 OUT="${XDG_CONFIG_HOME:-$HOME/.config}/k9s/skins"
 mkdir -p "$OUT"
-curl -L https://github.com/catppuccin/k9s/archive/main.tar.gz | tar x -C "$OUT" --strip-components=2 k9s-main/dist
+curl -L https://github.com/catppuccin/k9s/archive/main.tar.gz | tar xz -C "$OUT" --strip-components=2 k9s-main/dist
 ```
 
 ### macOS
 ```bash
 OUT="${XDG_CONFIG_HOME:-$HOME/Library/Application Support}/k9s/skins"
 mkdir -p "$OUT"
-curl -L https://github.com/catppuccin/k9s/archive/main.tar.gz | tar x -C "$OUT" --strip-components=2 k9s-main/dist
+curl -L https://github.com/catppuccin/k9s/archive/main.tar.gz | tar xz -C "$OUT" --strip-components=2 k9s-main/dist
 ```
 
 2. Edit your `config.yaml` so that it sets `k9s.ui.skin` to a Catppuccin flavor.


### PR DESCRIPTION
Running the install commands on fedora 39 resulted in the following error:

```
dhulick@framework:~/.../k9s-main$ curl -L https://github.com/catppuccin/k9s/archive/main.tar.gz | tar x -C "$OUT" --strip-components=2 k9s-main/dist
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0tar: Archive is compressed. Use -z option
tar: Error is not recoverable: exiting now
100 19834    0 19834    0     0  17545      0 --:--:--  0:00:01 --:--:--  102k
curl: (23) Failure writing output to destination
```

Adding -z option fixed. Docs updated to reflect this.