### PR TITLE
Update Macchiato breadcrumb non-active color

### DIFF
--- a/dist/catppuccin-macchiato-transparent.yaml
+++ b/dist/catppuccin-macchiato-transparent.yaml
@@ -28,7 +28,7 @@ k9s:
       keyColor: '#8aadf4'
       numKeyColor: '#ee99a0'
     crumbs:
-      fgColor: '#24273a'
+      fgColor: '#6e738d'
       bgColor: default
       activeColor: '#f0c6c6'
     status:

--- a/dist/catppuccin-macchiato.yaml
+++ b/dist/catppuccin-macchiato.yaml
@@ -28,7 +28,7 @@ k9s:
       keyColor: '#8aadf4'
       numKeyColor: '#ee99a0'
     crumbs:
-      fgColor: '#24273a'
+      fgColor: '#6e738d'
       bgColor: '#ee99a0'
       activeColor: '#f0c6c6'
     status:


### PR DESCRIPTION
This PR Fixes the breadcrumb color for the Macchiato (and Macchiato Transparent) schemes. 

Before:
![image](https://github.com/user-attachments/assets/18622cce-2bec-48ba-a5b4-dc13d86742a4)


After:
![image](https://github.com/user-attachments/assets/f00120eb-6b6c-43e6-af1f-996faac1957b)
